### PR TITLE
Fix syntax highright on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ end
 
 It takes an optional second argument if you want a different entity class than the mapper's:
 
-```
+``` ruby
 class ProjectMapper < Minimapper::AR
   def owner_of(project)
     owner_record = find(project).owner


### PR DESCRIPTION
- before
  ![2013-07-15 18 08 28](https://f.cloud.github.com/assets/290782/796738/25fd64c8-ed2e-11e2-8646-c1aa997bd30c.png)
- after
  ![2013-07-15 18 08 34](https://f.cloud.github.com/assets/290782/796739/27284fac-ed2e-11e2-805e-bb5be00ce50a.png)
